### PR TITLE
Version mismatch/update

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "flexboxgrid": "^6.3.1",
     "gulp": "^3.9.1",
     "qdt-components": "1.1.51",
-    "vue": "2.5.2",
+    "vue": "2.6.7",
     "vue-highlightjs": "^1.3.3",
     "vue-router": "^3.0.1"
   },
@@ -59,9 +59,9 @@
     "url-loader": "^0.5.8",
     "vue-loader": "^13.3.0",
     "vue-style-loader": "^3.0.1",
-    "vue-template-compiler": "^2.5.2",
+    "vue-template-compiler": "2.6.7",
     "webpack": "^3.6.0",
-    "webpack-bundle-analyzer": "^2.9.0",
+    "webpack-bundle-analyzer": "2.9.0",
     "webpack-dev-server": "^2.9.1",
     "webpack-merge": "^4.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "flexboxgrid": "^6.3.1",
     "gulp": "^3.9.1",
     "qdt-components": "1.1.51",
-    "vue": "2.6.7",
+    "vue": "^2.6.7",
     "vue-highlightjs": "^1.3.3",
     "vue-router": "^3.0.1"
   },
@@ -59,7 +59,7 @@
     "url-loader": "^0.5.8",
     "vue-loader": "^13.3.0",
     "vue-style-loader": "^3.0.1",
-    "vue-template-compiler": "2.6.7",
+    "vue-template-compiler": "^2.6.7",
     "webpack": "^3.6.0",
     "webpack-bundle-analyzer": "2.9.0",
     "webpack-dev-server": "^2.9.1",


### PR DESCRIPTION
vue-template-compiler has been updated to 2.6.7 which causes a version mismatch error with vue 2.5.2. All versions updated to ^2.6.7